### PR TITLE
Update config XML

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,8 @@ Authors@R: c(
     person("Bob", "Rudis", email = "bob@rud.is", role = c("aut", "cre"), 
            comment = c(ORCID = "0000-0001-5670-2640")),
     person("Bryce", "Mecum", email = "petridish@gmail.com", role = "ctb",
-           comment = c(ORCID = "0000-0002-0381-3766"))
+           comment = c(ORCID = "0000-0002-0381-3766")),
+    person("Garrett", "Mooney", email = "gmooney@mail.bradley.edu", role = "ctb"),
   )
 Author: Bob Rudis (bob@rud.is)
 Maintainer: Bob Rudis <bob@rud.is>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Authors@R: c(
            comment = c(ORCID = "0000-0001-5670-2640")),
     person("Bryce", "Mecum", email = "petridish@gmail.com", role = "ctb",
            comment = c(ORCID = "0000-0002-0381-3766")),
-    person("Garrett", "Mooney", email = "gmooney@mail.bradley.edu", role = "ctb"),
+    person("Garrett", "Mooney", email = "gmooney@mail.bradley.edu", role = "ctb")
   )
 Author: Bob Rudis (bob@rud.is)
 Maintainer: Bob Rudis <bob@rud.is>

--- a/R/config.r
+++ b/R/config.r
@@ -14,6 +14,7 @@ spd_config <- function() {
   config <- httr::content(res, as="text")
   config <- xml2::read_xml(config)
   config <- xml2::as_list(config)
+  config <- config$settings
   config <- purrr::map(config, function(.x) { c(.x, attributes(.x)) })
   config$`server-config`$ignoreids <- strsplit(config$`server-config`$ignoreids, ",")[[1]]
 


### PR DESCRIPTION
Running `README.Rmd` currently returns the error:
![config_error](https://user-images.githubusercontent.com/4910020/35365115-c3d7d61c-0140-11e8-9c7b-88e7c40a717f.png)

It appears that [http://www.speedtest.net/speedtest-config.php]() now wraps a `<settings>` tag around their config:
![get](https://user-images.githubusercontent.com/4910020/35365143-dfbab138-0140-11e8-86f5-fb0eb58e334e.png)
![config_settings](https://user-images.githubusercontent.com/4910020/35365127-cf30a21e-0140-11e8-8e50-08da70161cdc.png)

The change in `R/config.r` was made to subset `config` to `config$settings` after converting the XML to a list. ```config$`server-config` ``` now returns the expected results instead of `NULL`.