### PR TITLE
Minor tweaks for CRAN compliance

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,4 +15,5 @@
 ^LICENSE\.md$
 ^Makefile$
 ^appveyor\.yml$
-
+^README\.Rmd$
+^README\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,10 @@ Authors@R: c( person("Bob", "Rudis", email = "bob@rud.is",
       email = "petridish@gmail.com", role = "ctb", comment
       = c(ORCID = "0000-0002-0381-3766")),
       person("Garrett", "Mooney", email =
-      "gmooney@mail.bradley.edu", role = "ctb") )
+      "gmooney@mail.bradley.edu", role = "ctb"), 
+      person("Steve", "Condylios", email = 
+      "steve.condylios@gmail.com", role = "ctb", comment 
+      = c(ORCID = "0000-0003-0599-844X")) )
 Maintainer: Bob Rudis <bob@rud.is>
 Description: The 'Ookla' 'Speedtest' site
       <http://beta.speedtest.net/about> provides

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: speedtest
 Type: Package
 Title: Tools to Test and Compare Internet Bandwidth Speeds
 Version: 0.2.0
-Date: 2019-07-24
+Date: 2019-08-31
 Authors@R: c( person("Bob", "Rudis", email = "bob@rud.is",
       role = c("aut", "cre"), comment = c(ORCID =
       "0000-0001-5670-2640")), person("Bryce", "Mecum",


### PR DESCRIPTION
An error (to do with retrieving badges used in markdown) is avoided by not including the markdown files in the tarball sent to CRAN.

`speedtest` now passes check `--as-cran`

speedtest should now pass